### PR TITLE
feat: HOME-01, 02, 03 구현 (#11)

### DIFF
--- a/src/main/java/com/example/MatchaTonic/Back/controller/ProjectController.java
+++ b/src/main/java/com/example/MatchaTonic/Back/controller/ProjectController.java
@@ -26,7 +26,7 @@ public class ProjectController {
     private final ProjectService projectService;
     private final UserRepository userRepository;
 
-    @Operation(summary = "새 프로젝트 생성 (PROJ-01)")
+    @Operation(summary = "새 프로젝트 생성 (PROJ-01, PROJ-02)")
     @PostMapping
     public ResponseEntity<ProjectDto.CreateResponse> createProject(
             @Parameter(hidden = true) @AuthenticationPrincipal OAuth2User principal,
@@ -35,6 +35,16 @@ public class ProjectController {
         User user = getUserFromPrincipal(principal);
         ProjectDto.CreateResponse response = projectService.createProject(request, user);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Operation(summary = "내 프로젝트 목록 조회 (HOME-01, HOME-02)")
+    @GetMapping("/me")
+    public ResponseEntity<List<ProjectDto.CreateResponse>> getMyProjects(
+            @Parameter(hidden = true) @AuthenticationPrincipal OAuth2User principal) {
+
+        User user = getUserFromPrincipal(principal);
+        List<ProjectDto.CreateResponse> response = projectService.getMyProjects(user);
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "초대 코드로 프로젝트 참여 (PROJ-04)")

--- a/src/main/java/com/example/MatchaTonic/Back/dto/ProjectDto.java
+++ b/src/main/java/com/example/MatchaTonic/Back/dto/ProjectDto.java
@@ -18,8 +18,10 @@ public class ProjectDto {
     @Getter
     @Builder
     public static class CreateResponse {
+        private String name;
         private Long projectId;
         private String inviteCode;
         private String status;
+        private Long chatRoomId;
     }
 }

--- a/src/main/java/com/example/MatchaTonic/Back/service/ProjectService.java
+++ b/src/main/java/com/example/MatchaTonic/Back/service/ProjectService.java
@@ -5,7 +5,6 @@ import com.example.MatchaTonic.Back.dto.ProjectDto;
 import com.example.MatchaTonic.Back.entity.login.User;
 import com.example.MatchaTonic.Back.entity.project.Project;
 import com.example.MatchaTonic.Back.entity.project.ProjectMember;
-import com.example.MatchaTonic.Back.repository.login.UserRepository;
 import com.example.MatchaTonic.Back.repository.project.ProjectMemberRepository;
 import com.example.MatchaTonic.Back.repository.project.ProjectRepository;
 import lombok.RequiredArgsConstructor;
@@ -42,9 +41,25 @@ public class ProjectService {
 
         return ProjectDto.CreateResponse.builder()
                 .projectId(savedProject.getId())
+                .name(savedProject.getName())
                 .inviteCode(savedProject.getInviteCode())
                 .status(savedProject.getStatus())
+                .chatRoomId(savedProject.getId())
                 .build();
+    }
+
+    // [HOME-01] 내 프로젝트 목록 조회
+    @Transactional(readOnly = true)
+    public List<ProjectDto.CreateResponse> getMyProjects(User user) {
+        return projectMemberRepository.findByUser(user).stream()
+                .map(member -> ProjectDto.CreateResponse.builder()
+                        .projectId(member.getProject().getId())
+                        .name(member.getProject().getName())
+                        .inviteCode(member.getProject().getInviteCode())
+                        .status(member.getProject().getStatus())
+                        .chatRoomId(member.getProject().getId())
+                        .build())
+                .collect(Collectors.toList());
     }
 
     // [PROJ-04] 초대 코드로 가입 로직


### PR DESCRIPTION
## 작업 요약
- HOME-01: ProjectService에 내 프로젝트 목록 조회 기능을 추가하고, ProjectController에 엔드포인트 연결(ProjectMemberRepository 사용)
- HOME-02: ProjectDto에 chatRoomId 필드를 추가합니다. 현재 ChatController를 확인한 결과 projectId를 채팅방 ID로 하여 매핑
HOME-03: 프로젝트 추가 진입은 기존 createProject, joinProject API를 활용하는 방향으로  구현

## 🔗 관련 이슈
- Closes #11

## 주요 변경 사항
- 

## 체크리스트
- [x] 불필요한 로그/디버그 코드 제거
- [x] 예외 처리 및 에러 코드 반영


