### PR TITLE
feat: session요약 저장을 나눠 테이블 형태로 저장

### DIFF
--- a/src/main/java/com/example/MatchaTonic/Back/controller/ProjectController.java
+++ b/src/main/java/com/example/MatchaTonic/Back/controller/ProjectController.java
@@ -78,12 +78,6 @@ public class ProjectController {
         return ResponseEntity.ok("프로젝트가 삭제되었습니다.");
     }
 
-    private User getUserFromEmail(String email) {
-        if (email == null) throw new RuntimeException("인증 정보가 없습니다.");
-        return userRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
-    }
-
     @Operation(summary = "AI 분석 및 노션으로 내보내기")
     @PostMapping("/{projectId}/export")
     public ResponseEntity<String> exportToNotion(
@@ -101,5 +95,37 @@ public class ProjectController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body("내보내기 중 오류가 발생했습니다: " + e.getMessage());
         }
+    }
+
+    @Operation(summary = "프로젝트 상세 조회 (정형화된 세션 요약 포함)")
+    @GetMapping("/{projectId}")
+    public ResponseEntity<ProjectDto.DetailResponse> getProjectDetail(
+            @PathVariable Long projectId,
+            @Parameter(hidden = true) @AuthenticationPrincipal String email) {
+
+        User user = getUserFromEmail(email);
+        ProjectDto.DetailResponse response = projectService.getProjectDetail(projectId, user);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     *  프로젝트 세션 요약 수동 업데이트
+     */
+    @Operation(summary = "프로젝트 세션 요약 수동 업데이트 (항목별 업데이트)")
+    @PatchMapping("/{projectId}/summary")
+    public ResponseEntity<String> updateSessionSummary(
+            @PathVariable Long projectId,
+            @RequestBody ProjectDto.SummaryUpdateRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal String email) {
+
+        User user = getUserFromEmail(email);
+        projectService.updateSessionSummary(projectId, request, user);
+        return ResponseEntity.ok("세션 요약이 성공적으로 업데이트되었습니다.");
+    }
+
+    private User getUserFromEmail(String email) {
+        if (email == null) throw new RuntimeException("인증 정보가 없습니다.");
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/example/MatchaTonic/Back/dto/ProjectDto.java
+++ b/src/main/java/com/example/MatchaTonic/Back/dto/ProjectDto.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class ProjectDto {
@@ -50,5 +51,55 @@ public class ProjectDto {
     public static class TeamResponse {
         private String inviteCode;
         private List<MemberDto.InfoResponse> members;
+    }
+
+    /**
+     * 프로젝트 상세 조회 응답
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DetailResponse {
+        private Long id;
+        private String name;
+        private String subject;
+        private String inviteCode;
+        private String status;
+        private Long chatRoomId;
+        private SessionSummaryDto summary;
+    }
+
+    /**
+     * 정형화된 세션 요약 정보를 위한 내부 DTO
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SessionSummaryDto {
+        private String title;
+        private String goal;
+        private String teamSize;
+        private String roles;
+        private String dueDate;
+        private String deliverables;
+        private String updatedSource;
+        private LocalDateTime updatedAt;
+    }
+
+    /**
+     * 수동으로 요약을 수정할 때 사용하는 요청 DTO
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SummaryUpdateRequest {
+        private String title;
+        private String goal;
+        private String teamSize;
+        private String roles;
+        private String dueDate;
+        private String deliverables;
     }
 }

--- a/src/main/java/com/example/MatchaTonic/Back/entity/project/Project.java
+++ b/src/main/java/com/example/MatchaTonic/Back/entity/project/Project.java
@@ -36,6 +36,9 @@ public class Project {
     @Column(nullable = false)
     private String status;
 
+    @OneToOne(mappedBy = "project", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private ProjectSessionSummary projectSessionSummary;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "leader_id")
     private User leader;
@@ -65,5 +68,16 @@ public class Project {
 
     public void updateStatus(String status) {
         this.status = status;
+    }
+
+    /**
+     * 프로젝트 상세 조회 등에서 요약본이 필요할 때 호출하는 메서드
+     * 이제 정형 데이터 테이블에서 값을 가져오거나 없으면 기본 메시지를 반환합니다.
+     */
+    public String getSessionSummaryText() {
+        if (projectSessionSummary == null || projectSessionSummary.getGoal() == null) {
+            return "아직 생성된 요약이 없습니다.";
+        }
+        return projectSessionSummary.getGoal(); // 혹은 필드들을 합쳐서 반환 가능
     }
 }

--- a/src/main/java/com/example/MatchaTonic/Back/entity/project/ProjectSessionSummary.java
+++ b/src/main/java/com/example/MatchaTonic/Back/entity/project/ProjectSessionSummary.java
@@ -1,0 +1,77 @@
+package com.example.MatchaTonic.Back.entity.project;
+
+import com.example.MatchaTonic.Back.entity.login.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "project_session_summaries")
+public class ProjectSessionSummary {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", unique = true)
+    private Project project;
+
+    private String title;         // 프로젝트 명칭
+
+    @Column(columnDefinition = "TEXT")
+    private String goal;          // 목표
+
+    private String teamSize;      // 팀 규모
+
+    @Column(columnDefinition = "TEXT")
+    private String roles;         // 역할 분담
+
+    private String dueDate;       // 마감 기한
+
+    @Column(columnDefinition = "TEXT")
+    private String deliverables;  // 최종 결과물
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "updated_by_id")
+    private User updatedBy;       // 마지막 수정자
+
+    private String updatedSource; // "AI" 또는 "MANUAL"
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public ProjectSessionSummary(Project project, String title, String goal, String teamSize,
+                                 String roles, String dueDate, String deliverables,
+                                 User updatedBy, String updatedSource) {
+        this.project = project;
+        this.title = title;
+        this.goal = goal;
+        this.teamSize = teamSize;
+        this.roles = roles;
+        this.dueDate = dueDate;
+        this.deliverables = deliverables;
+        this.updatedBy = updatedBy;
+        this.updatedSource = updatedSource;
+    }
+
+    // 업데이트를 위한 편의 메서드
+    public void updateAll(String title, String goal, String teamSize, String roles,
+                          String dueDate, String deliverables, User updatedBy, String updatedSource) {
+        this.title = title;
+        this.goal = goal;
+        this.teamSize = teamSize;
+        this.roles = roles;
+        this.dueDate = dueDate;
+        this.deliverables = deliverables;
+        this.updatedBy = updatedBy;
+        this.updatedSource = updatedSource;
+    }
+}

--- a/src/main/java/com/example/MatchaTonic/Back/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/MatchaTonic/Back/exception/GlobalExceptionHandler.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice // 모든 컨트롤러의 예외를 감시합니다
 public class GlobalExceptionHandler {
 
-    // 우리가 AiService에서 던졌던 RuntimeException을 처리합니다.
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException e) {
         log.error("비즈니스 로직 에러 발생: {}", e.getMessage());
@@ -19,7 +18,7 @@ public class GlobalExceptionHandler {
         ErrorResponse response = ErrorResponse.builder()
                 .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
                 .code("BIZ_ERROR")
-                .message(e.getMessage()) // "AI 분석 서버와 통신할 수 없습니다" 등이 전달됨
+                .message(e.getMessage())
                 .build();
 
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/example/MatchaTonic/Back/repository/project/ProjectSessionSummaryRepository.java
+++ b/src/main/java/com/example/MatchaTonic/Back/repository/project/ProjectSessionSummaryRepository.java
@@ -1,0 +1,11 @@
+package com.example.MatchaTonic.Back.repository.project;
+
+import com.example.MatchaTonic.Back.entity.project.Project;
+import com.example.MatchaTonic.Back.entity.project.ProjectSessionSummary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface ProjectSessionSummaryRepository extends JpaRepository<ProjectSessionSummary, Long> {
+    Optional<ProjectSessionSummary> findByProject(Project project);
+    Optional<ProjectSessionSummary> findByProjectId(Long projectId);
+}

--- a/src/main/java/com/example/MatchaTonic/Back/service/ChatService.java
+++ b/src/main/java/com/example/MatchaTonic/Back/service/ChatService.java
@@ -6,9 +6,11 @@ import com.example.MatchaTonic.Back.dto.ChatMessageDto;
 import com.example.MatchaTonic.Back.entity.login.User;
 import com.example.MatchaTonic.Back.entity.project.ChatMessage;
 import com.example.MatchaTonic.Back.entity.project.Project;
+import com.example.MatchaTonic.Back.entity.project.ProjectSessionSummary;
 import com.example.MatchaTonic.Back.repository.login.UserRepository;
 import com.example.MatchaTonic.Back.repository.project.ChatMessageRepository;
 import com.example.MatchaTonic.Back.repository.project.ProjectRepository;
+import com.example.MatchaTonic.Back.repository.project.ProjectSessionSummaryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,6 +36,9 @@ public class ChatService {
     private final SimpMessageSendingOperations messagingTemplate;
     private final RestTemplate restTemplate;
 
+    // 정형 데이터 리포지토리
+    private final ProjectSessionSummaryRepository summaryRepository;
+
     @Value("${external.api.fastapi.chat-url}")
     private String aiChatUrl;
 
@@ -45,17 +50,14 @@ public class ChatService {
         Project project = projectRepository.findById(dto.getProjectId())
                 .orElseThrow(() -> new RuntimeException("프로젝트를 찾을 수 없습니다."));
 
-        // 프론트에서 type을 안 보냈을 경우 기본 TALK로 설정
         if (dto.getType() == null) {
             dto.setType(ChatMessageDto.MessageType.TALK);
         }
 
-        // 1. DB 저장 (ENTER 타입 제외)
         if (!ChatMessageDto.MessageType.ENTER.equals(dto.getType())) {
             saveToDb(dto, project);
         }
 
-        // 2. 시간 설정 및 브로드캐스트
         if (dto.getCreatedAt() == null) {
             dto.setCreatedAt(LocalDateTime.now());
         }
@@ -63,7 +65,6 @@ public class ChatService {
         log.info("Broadcasting message to /sub/project/{}", dto.getProjectId());
         messagingTemplate.convertAndSend("/sub/project/" + dto.getProjectId(), dto);
 
-        // [수정] 3. AI 호출 조건: TALK 타입 + 발신자가 AI 아님 + 메시지에 "@mates" 포함 시에만 호출
         boolean isTalk = ChatMessageDto.MessageType.TALK.equals(dto.getType());
         boolean isNotAi = !"ai@promate.ai".equals(dto.getSenderEmail());
         boolean hasAiMention = dto.getMessage() != null && dto.getMessage().contains("@mates");
@@ -71,8 +72,6 @@ public class ChatService {
         if (isTalk && isNotAi && hasAiMention) {
             log.info("AI 호출 조건을 만족함 (@mates 감지): 프로젝트ID={}", project.getId());
             callAiAndBroadcast(project, dto);
-        } else {
-            log.info("AI 호출 조건 미충족 (일반 대화 또는 호출어 없음)");
         }
     }
 
@@ -98,20 +97,73 @@ public class ChatService {
             AiChatResponseDto response = restTemplate.postForObject(aiChatUrl, request, AiChatResponseDto.class);
 
             if (response != null && response.content() != null) {
+                String aiContent = response.content();
+
                 ChatMessageDto aiDto = ChatMessageDto.builder()
                         .type(ChatMessageDto.MessageType.SYSTEM)
                         .projectId(project.getId())
                         .senderName("Promate AI")
                         .senderEmail("ai@promate.ai")
-                        .message(response.content())
+                        .message(aiContent)
                         .createdAt(LocalDateTime.now())
                         .build();
 
                 saveToDb(aiDto, project);
+
+                if (shouldUpdateSummary(aiContent)) {
+                    updateProjectSummary(project, aiContent);
+                }
+
                 messagingTemplate.convertAndSend("/sub/project/" + project.getId(), aiDto);
             }
         } catch (Exception e) {
             log.error("AI 응답 처리 중 오류 발생: {}", e.getMessage());
+        }
+    }
+
+    private boolean shouldUpdateSummary(String content) {
+        if (content == null) return false;
+        boolean hasKeyWords = content.contains("요약") || content.contains("결정") ||
+                content.contains("확정") || content.contains("정리") ||
+                content.contains("선정");
+        boolean isLongEnough = content.length() > 100;
+        return hasKeyWords || isLongEnough;
+    }
+
+    /**
+     * AI 응답을 정형 데이터 테이블에 저장하는 로직
+     */
+    @Transactional
+    protected void updateProjectSummary(Project project, String aiContent) {
+        try {
+            ProjectSessionSummary summary = summaryRepository.findByProject(project)
+                    .orElseGet(() -> ProjectSessionSummary.builder()
+                            .project(project)
+                            .updatedSource("AI")
+                            .build());
+
+            summary.updateAll(
+                    project.getName(),   // title
+                    aiContent,           // goal
+                    "논의 중",            // teamSize
+                    "분석 중",            // roles
+                    "미정",               // dueDate
+                    "기획안",             // deliverables
+                    null,                // updatedBy
+                    "AI"
+            );
+
+            summaryRepository.save(summary);
+
+            // 2. 상태 변경 (기획 완료 단계로 진입)
+            if (aiContent.length() > 20) {
+                project.updateStatus("PLANNING_DONE");
+            }
+
+            projectRepository.save(project);
+            log.info("정형 세션 요약 테이블 및 프로젝트 상태(PLANNING_DONE) 자동 갱신 완료: ID={}", project.getId());
+        } catch (Exception e) {
+            log.error("세션 요약 데이터 정형화 저장 실패: {}", e.getMessage());
         }
     }
 
@@ -121,7 +173,6 @@ public class ChatService {
             sender = userRepository.findByEmail(dto.getSenderEmail()).orElse(null);
         }
 
-        // Enum 매핑 안전하게 처리
         ChatMessage.MessageType entityType = ChatMessage.MessageType.TALK;
         if (dto.getType() != null) {
             try {
@@ -158,7 +209,6 @@ public class ChatService {
                     .createdAt(LocalDateTime.now())
                     .build();
 
-            // 입장 인사말은 "@mates" 체크 없이 즉시 전송
             saveToDb(aiMsg, project);
             messagingTemplate.convertAndSend("/sub/project/" + projectId, aiMsg);
         }

--- a/src/main/java/com/example/MatchaTonic/Back/service/ProjectService.java
+++ b/src/main/java/com/example/MatchaTonic/Back/service/ProjectService.java
@@ -5,8 +5,10 @@ import com.example.MatchaTonic.Back.dto.ProjectDto;
 import com.example.MatchaTonic.Back.entity.login.User;
 import com.example.MatchaTonic.Back.entity.project.Project;
 import com.example.MatchaTonic.Back.entity.project.ProjectMember;
+import com.example.MatchaTonic.Back.entity.project.ProjectSessionSummary;
 import com.example.MatchaTonic.Back.repository.project.ProjectMemberRepository;
 import com.example.MatchaTonic.Back.repository.project.ProjectRepository;
+import com.example.MatchaTonic.Back.repository.project.ProjectSessionSummaryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,6 +25,7 @@ public class ProjectService {
 
     private final ProjectRepository projectRepository;
     private final ProjectMemberRepository projectMemberRepository;
+    private final ProjectSessionSummaryRepository summaryRepository; // 정형 데이터 리포지토리 추가
 
     /**
      * 프로젝트 생성
@@ -126,5 +129,80 @@ public class ProjectService {
         }
 
         projectRepository.delete(project);
+    }
+
+    /**
+     * 프로젝트 상세 조회 (정형화된 세션 요약 포함)
+     */
+    @Transactional(readOnly = true)
+    public ProjectDto.DetailResponse getProjectDetail(Long projectId, User user) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
+
+        projectMemberRepository.findByUserAndProject(user, project)
+                .orElseThrow(() -> new IllegalStateException("해당 프로젝트에 접근 권한이 없습니다."));
+
+        // 정형 요약 데이터 조회 (없을 경우 빈 객체 처리)
+        ProjectSessionSummary summary = summaryRepository.findByProject(project).orElse(null);
+        ProjectDto.SessionSummaryDto summaryDto = null;
+
+        if (summary != null) {
+            summaryDto = ProjectDto.SessionSummaryDto.builder()
+                    .title(summary.getTitle())
+                    .goal(summary.getGoal())
+                    .teamSize(summary.getTeamSize())
+                    .roles(summary.getRoles())
+                    .dueDate(summary.getDueDate())
+                    .deliverables(summary.getDeliverables())
+                    .updatedSource(summary.getUpdatedSource())
+                    .updatedAt(summary.getUpdatedAt())
+                    .build();
+        }
+
+        return ProjectDto.DetailResponse.builder()
+                .id(project.getId())
+                .name(project.getName())
+                .subject(project.getSubject())
+                .inviteCode(project.getInviteCode())
+                .status(project.getStatus())
+                .chatRoomId(project.getId())
+                .summary(summaryDto) // String 대신 DTO 전달
+                .build();
+    }
+
+    /**
+     * 프로젝트 세션 요약 수동 업데이트 (정형 데이터 방식)
+     */
+    public void updateSessionSummary(Long projectId, ProjectDto.SummaryUpdateRequest request, User user) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("프로젝트를 찾을 수 없습니다."));
+
+        projectMemberRepository.findByUserAndProject(user, project)
+                .orElseThrow(() -> new IllegalStateException("업데이트 권한이 없습니다."));
+
+        // 기존 요약 정보를 찾거나 새로 생성
+        ProjectSessionSummary summary = summaryRepository.findByProject(project)
+                .orElseGet(() -> ProjectSessionSummary.builder()
+                        .project(project)
+                        .build());
+
+        summary.updateAll(
+                request.getTitle(),
+                request.getGoal(),
+                request.getTeamSize(),
+                request.getRoles(),
+                request.getDueDate(),
+                request.getDeliverables(),
+                user,
+                "MANUAL"
+        );
+
+        summaryRepository.save(summary);
+
+        if (request.getGoal() != null && request.getGoal().length() > 5) {
+            project.updateStatus("PLANNING_DONE");
+        }
+
+        log.info("프로젝트 정형 요약 수동 업데이트 완료 - ID: {}, 유저: {}", projectId, user.getEmail());
     }
 }


### PR DESCRIPTION
## 작업 요약
- 비정형 데이터(채팅)의 정형 자산화를 위한 도메인 모델 고도화 및 API 구현
- AI 응답 및 수동 입력 데이터를 항목별(목표, 역할, 마감기한 등)로 관리할 수 있는 구조 구축
- 프로젝트 상태 관리 로직 최적화를 통한 단계별 프로세스(기획 -> 템플릿 생성) 연결

## 🔗 관련 이슈
- Closes #17

## 주요 변경 사항
- DB 스키마 정규화: 기존 projects 테이블의 sessionSummary 텍스트 필드를 제거하고, 별도의 project_session_summaries 테이블(1:1 관계)을 생성하여 데이터를 구조화함.
- AI 응답 필터링 및 자동 갱신: ChatService에 shouldUpdateSummary 로직을 추가하여, AI의 단순 답변은 배제하고 프로젝트에 유의미한 '요약/결정' 사항만 자동 저장하도록 구현.
- 프로젝트 상세 조회 API 고도화: GET /api/projects/{projectId} 호출 시, 정형화된 요약 데이터(SessionSummaryDto)를 포함하여 응답하도록 수정.
- 상태 전이 로직 반영: 요약 데이터가 생성(AI 또는 수동)되면 프로젝트 상태를 PLANNING_DONE으로 자동 변경하여 프론트엔드에서 다음 단계(템플릿 생성) 버튼이 활성화되도록 트리거 제공.
- 예외 처리 강화: GlobalExceptionHandler를 통해 비즈니스 로직 에러와 서버 내부 오류를 구분하여 응답하도록 개선

## 체크리스트
- [x] 불필요한 로그/디버그 코드 제거
- [x] 예외 처리 및 에러 코드 반영
- [x] 엔티티-DTO 간 필드 매핑 무결성 확인
- [x] API 응답 구조와 프론트엔드 요구사항 일치 확인


